### PR TITLE
Fix Data preparation logic

### DIFF
--- a/medperf/data_preparator/project/prepare.py
+++ b/medperf/data_preparator/project/prepare.py
@@ -1,5 +1,5 @@
 import os, pathlib
-import shutil
+from distutils.dir_util import copy_tree
 import argparse
 
 if __name__ == '__main__':
@@ -9,6 +9,4 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    pathlib.Path.mkdir(args.out, parents=True, exist_ok=True)
-
-    shutil.copytree(args.input, args.out)
+    copy_tree(args.input, args.out)

--- a/medperf/data_preparator/project/statistics.py
+++ b/medperf/data_preparator/project/statistics.py
@@ -2,7 +2,7 @@ import os
 import yaml
 import argparse
 
-from .sanity_check import check_subject_validity            
+from sanity_check import check_subject_validity            
 
 def get_statistics(data_path: str) -> dict:
     """Computes statistics about the data. This statistics are uploaded


### PR DESCRIPTION
The prepare and statistics tasks were failing due to `copytree` and a relative import. This should not affect medperf's submission, as it doesn't modify `mlcube.yaml` nor `parameters.yaml`